### PR TITLE
Fix concurrency

### DIFF
--- a/pkg/config/scenario.go
+++ b/pkg/config/scenario.go
@@ -35,9 +35,9 @@ func (s *Scenario) Start() {
 		}
 
 		go func(a SimpleConfiguration) {
+			defer wg.Done()
 			if err := a.Start(); err != nil {
 				log.Println(err)
-				wg.Done()
 				return
 			}
 		}(a)


### PR DESCRIPTION
Fixed that `wg.Done` was called only when an error occurred, so it did not terminate even if all scenarios were processed.